### PR TITLE
Fix: Replace props.total_mem with props.total_memory

### DIFF
--- a/scripts/auto_config.py
+++ b/scripts/auto_config.py
@@ -105,7 +105,7 @@ def detect_hardware(device_override: str | None = None) -> HardwareInfo:
     if device == "cuda" and torch.cuda.is_available():
         props = torch.cuda.get_device_properties(0)
         device_name = props.name
-        vram_gb = props.total_mem / (1024**3)
+        vram_gb = props.total_memory / (1024**3)
         cuda_version = torch.version.cuda or ""
         gpu_count = torch.cuda.device_count()
     elif device == "mps":


### PR DESCRIPTION
## Problem
Fixes #1

The script was using `props.total_mem` which does not exist in PyTorch CUDA device properties.

## Solution
Changed `props.total_mem` to `props.total_memory` (the correct attribute name).

## Changes
- Line 108 in `scripts/auto_config.py`

## Testing
This fix aligns with PyTorch official API:
```python
torch.cuda.get_device_properties(0).total_memory
```

## Impact
- Fixes AttributeError when running the script
- No breaking changes
- Minimal code change (1 line)